### PR TITLE
feat(ToiletReport): 화장실 익명 제보 게시판 관련 API 구현(#17)

### DIFF
--- a/src/main/java/com/daeddong/controller/ToiletReportController.java
+++ b/src/main/java/com/daeddong/controller/ToiletReportController.java
@@ -1,0 +1,121 @@
+package com.daeddong.controller;
+
+import com.daeddong.domain.ToiletReport.ReportStatus;
+import com.daeddong.dto.request.ToiletReportRequest;
+import com.daeddong.dto.response.ToiletReportResponse;
+import com.daeddong.global.response.ApiResponse;
+import com.daeddong.service.ToiletReportService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+@Validated
+public class ToiletReportController {
+
+    private final ToiletReportService reportService;
+
+    /**
+     * 화장실 제보 등록
+     * POST /api/v1/reports
+     * Content-Type: multipart/form-data
+     * - data: ToiletReportRequest JSON (필수/선택 필드 포함)
+     * - image: 현장 사진 (optional)
+     */
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<ToiletReportResponse>> createReport(
+            @RequestPart("data") @Valid ToiletReportRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok("제보가 등록되었습니다. 관리자 검토 후 지도에 반영됩니다.",
+                        reportService.createReport(request, image)));
+    }
+
+    /**
+     * 내 제보 목록
+     * GET /api/v1/reports/my?deviceId=xxx
+     */
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<Page<ToiletReportResponse>>> getMyReports(
+            @RequestParam @NotBlank String deviceId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(reportService.getMyReports(deviceId, pageable)));
+    }
+
+    /**
+     * 제보 단건 조회
+     * GET /api/v1/reports/{reportId}
+     */
+    @GetMapping("/{reportId}")
+    public ResponseEntity<ApiResponse<ToiletReportResponse>> getReport(
+            @PathVariable Long reportId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(reportService.getReport(reportId)));
+    }
+
+    /**
+     * 제보 삭제 (본인 + PENDING 상태만)
+     * DELETE /api/v1/reports/{reportId}?deviceId=xxx
+     */
+    @DeleteMapping("/{reportId}")
+    public ResponseEntity<ApiResponse<Void>> deleteReport(
+            @PathVariable Long reportId,
+            @RequestParam @NotBlank String deviceId
+    ) {
+        reportService.deleteReport(reportId, deviceId);
+        return ResponseEntity.ok(ApiResponse.ok("제보가 삭제되었습니다."));
+    }
+
+    // ── 관리자 ────────────────────────────────────────────
+
+    /**
+     * 상태별 제보 목록 (관리자)
+     * GET /api/v1/reports/admin?status=PENDING
+     */
+    @GetMapping("/admin")
+    public ResponseEntity<ApiResponse<Page<ToiletReportResponse>>> getReportsByStatus(
+            @RequestParam(defaultValue = "PENDING") ReportStatus status,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(reportService.getReportsByStatus(status, pageable)));
+    }
+
+    /**
+     * 제보 승인 → 화장실 자동 등록 (관리자)
+     * PATCH /api/v1/reports/{reportId}/approve
+     */
+    @PatchMapping("/{reportId}/approve")
+    public ResponseEntity<ApiResponse<ToiletReportResponse>> approveReport(
+            @PathVariable Long reportId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                "제보가 승인되어 화장실이 지도에 등록되었습니다.",
+                reportService.approveReport(reportId)));
+    }
+
+    /**
+     * 제보 반려 (관리자)
+     * PATCH /api/v1/reports/{reportId}/reject
+     */
+    @PatchMapping("/{reportId}/reject")
+    public ResponseEntity<ApiResponse<ToiletReportResponse>> rejectReport(
+            @PathVariable Long reportId
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok("제보가 반려되었습니다.",
+                reportService.rejectReport(reportId)));
+    }
+}

--- a/src/main/java/com/daeddong/dto/request/ToiletReportRequest.java
+++ b/src/main/java/com/daeddong/dto/request/ToiletReportRequest.java
@@ -1,0 +1,52 @@
+package com.daeddong.dto.request;
+
+import com.daeddong.domain.Toilet.OpenStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+/**
+ * 화장실 제보 요청 DTO
+ * Content-Type: multipart/form-data
+ * - data: 이 DTO (application/json)
+ * - image: 첨부 사진 (optional)
+ */
+@Getter
+public class ToiletReportRequest {
+
+    @NotBlank(message = "deviceId는 필수입니다.")
+    private String deviceId;
+
+    // ── 필수 ──────────────────────────────────────────
+
+    @NotBlank(message = "화장실 이름은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    private String address;
+
+    @NotNull(message = "위도(lat)는 필수입니다.")
+    private Double lat;
+
+    @NotNull(message = "경도(lng)는 필수입니다.")
+    private Double lng;
+
+    // ── 선택 ──────────────────────────────────────────
+
+    /** 운영 상태 (기본값: OPEN) */
+    private OpenStatus openStatus;
+
+    /** 장애인 화장실 여부 */
+    private Boolean isDisabled;
+
+    /** 남녀 구분 여부 */
+    private Boolean isGenderSep;
+
+    /** 운영 시간 (예: "06:00 ~ 22:00", "24시간") */
+    private String openHours;
+
+    /** 제보자 추가 메모 */
+    @Size(max = 500, message = "메모는 500자 이하여야 합니다.")
+    private String memo;
+}

--- a/src/main/java/com/daeddong/dto/response/ToiletReportResponse.java
+++ b/src/main/java/com/daeddong/dto/response/ToiletReportResponse.java
@@ -1,0 +1,53 @@
+package com.daeddong.dto.response;
+
+import com.daeddong.domain.Toilet.OpenStatus;
+import com.daeddong.domain.ToiletReport;
+import com.daeddong.domain.ToiletReport.ReportStatus;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ToiletReportResponse {
+
+    private Long id;
+    private String deviceId;
+
+    // 화장실 정보
+    private String name;
+    private String address;
+    private Double lat;
+    private Double lng;
+    private OpenStatus openStatus;
+    private Boolean isDisabled;
+    private Boolean isGenderSep;
+    private String openHours;
+
+    // 제보 메타
+    private String memo;
+    private String imageUrl;
+    private ReportStatus status;
+    private Long approvedToiletId;  // 승인 후 생성된 화장실 ID
+    private LocalDateTime createdAt;
+
+    public static ToiletReportResponse from(ToiletReport report) {
+        return ToiletReportResponse.builder()
+                .id(report.getId())
+                .deviceId(report.getDeviceId())
+                .name(report.getName())
+                .address(report.getAddress())
+                .lat(report.getLat())
+                .lng(report.getLng())
+                .openStatus(report.getOpenStatus())
+                .isDisabled(report.getIsDisabled())
+                .isGenderSep(report.getIsGenderSep())
+                .openHours(report.getOpenHours())
+                .memo(report.getMemo())
+                .imageUrl(report.getImageUrl())
+                .status(report.getStatus())
+                .approvedToiletId(report.getApprovedToiletId())
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/daeddong/repository/ToiletReportRepository.java
+++ b/src/main/java/com/daeddong/repository/ToiletReportRepository.java
@@ -1,0 +1,16 @@
+package com.daeddong.repository;
+
+import com.daeddong.domain.ToiletReport;
+import com.daeddong.domain.ToiletReport.ReportStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ToiletReportRepository extends JpaRepository<ToiletReport, Long> {
+
+    /** 상태별 전체 조회 (관리자용) */
+    Page<ToiletReport> findByStatusOrderByCreatedAtDesc(ReportStatus status, Pageable pageable);
+
+    /** 기기별 본인 제보 목록 */
+    Page<ToiletReport> findByDeviceIdOrderByCreatedAtDesc(String deviceId, Pageable pageable);
+}

--- a/src/main/java/com/daeddong/service/ToiletReportService.java
+++ b/src/main/java/com/daeddong/service/ToiletReportService.java
@@ -1,0 +1,142 @@
+package com.daeddong.service;
+
+import com.daeddong.domain.Toilet;
+import com.daeddong.domain.ToiletReport;
+import com.daeddong.domain.ToiletReport.ReportStatus;
+import com.daeddong.dto.request.ToiletReportRequest;
+import com.daeddong.dto.response.ToiletReportResponse;
+import com.daeddong.global.exception.DaeddongException;
+import com.daeddong.global.exception.ErrorCode;
+import com.daeddong.global.s3.S3Uploader;
+import com.daeddong.repository.ToiletRepository;
+import com.daeddong.repository.ToiletReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ToiletReportService {
+
+    private static final String S3_FOLDER = "reports";
+
+    private final ToiletReportRepository reportRepository;
+    private final ToiletRepository toiletRepository;
+    private final S3Uploader s3Uploader;
+    private final GeometryFactory geometryFactory;
+
+    /** 화장실 제보 등록 */
+    @Transactional
+    public ToiletReportResponse createReport(ToiletReportRequest request, MultipartFile image) {
+        String imageUrl = (image != null && !image.isEmpty())
+                ? s3Uploader.upload(image, S3_FOLDER)
+                : null;
+
+        ToiletReport report = ToiletReport.create(
+                request.getDeviceId(),
+                request.getName(), request.getAddress(), request.getLat(), request.getLng(),
+                request.getOpenStatus(),
+                request.getIsDisabled(), request.getIsGenderSep(),
+                request.getOpenHours(), request.getMemo(), imageUrl
+        );
+
+        return ToiletReportResponse.from(reportRepository.save(report));
+    }
+
+    /** 본인 제보 목록 */
+    public Page<ToiletReportResponse> getMyReports(String deviceId, Pageable pageable) {
+        return reportRepository.findByDeviceIdOrderByCreatedAtDesc(deviceId, pageable)
+                .map(ToiletReportResponse::from);
+    }
+
+    /** 제보 단건 조회 */
+    public ToiletReportResponse getReport(Long reportId) {
+        return ToiletReportResponse.from(findReport(reportId));
+    }
+
+    /** 상태별 전체 조회 (관리자) */
+    public Page<ToiletReportResponse> getReportsByStatus(ReportStatus status, Pageable pageable) {
+        return reportRepository.findByStatusOrderByCreatedAtDesc(status, pageable)
+                .map(ToiletReportResponse::from);
+    }
+
+    /** 제보 삭제 — 본인 + PENDING 상태만 가능 */
+    @Transactional
+    public void deleteReport(Long reportId, String deviceId) {
+        ToiletReport report = findReport(reportId);
+
+        if (!report.getDeviceId().equals(deviceId)) {
+            throw new DaeddongException(ErrorCode.REPORT_FORBIDDEN);
+        }
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new DaeddongException(ErrorCode.REPORT_ALREADY_PROCESSED);
+        }
+
+        s3Uploader.delete(report.getImageUrl());
+        reportRepository.delete(report);
+    }
+
+    /**
+     * 관리자: 제보 승인
+     * → 제보 정보를 기반으로 toilets 테이블에 새 화장실을 직접 생성
+     */
+    @Transactional
+    public ToiletReportResponse approveReport(Long reportId) {
+        ToiletReport report = findReport(reportId);
+
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new DaeddongException(ErrorCode.REPORT_ALREADY_PROCESSED);
+        }
+
+        // lat/lng → Point 변환 (SRID 4326)
+        Point location = geometryFactory.createPoint(
+                new Coordinate(report.getLng(), report.getLat())
+        );
+
+        // 선택 필드 기본값 처리
+        Toilet.OpenStatus openStatus = report.getOpenStatus() != null
+                ? report.getOpenStatus()
+                : Toilet.OpenStatus.OPEN;
+        boolean isDisabled = report.getIsDisabled() != null && report.getIsDisabled();
+        boolean isGenderSep = report.getIsGenderSep() == null || report.getIsGenderSep(); // 기본 true
+
+        Toilet toilet = Toilet.create(
+                report.getName(), report.getAddress(),
+                report.getLat(), report.getLng(), location,
+                openStatus, isDisabled, isGenderSep,
+                report.getOpenHours(), Toilet.Source.USER_REPORT
+        );
+
+        Toilet saved = toiletRepository.save(toilet);
+        report.approve(saved.getId());
+
+        return ToiletReportResponse.from(report);
+    }
+
+    /** 관리자: 제보 반려 */
+    @Transactional
+    public ToiletReportResponse rejectReport(Long reportId) {
+        ToiletReport report = findReport(reportId);
+
+        if (report.getStatus() != ReportStatus.PENDING) {
+            throw new DaeddongException(ErrorCode.REPORT_ALREADY_PROCESSED);
+        }
+
+        report.reject();
+        return ToiletReportResponse.from(report);
+    }
+
+    // ── private ───────────────────────────────────────
+
+    private ToiletReport findReport(Long reportId) {
+        return reportRepository.findById(reportId)
+                .orElseThrow(() -> new DaeddongException(ErrorCode.REPORT_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
화장실 익명 제보를 위한 기능을 구현하였습니다.
추가로, 관리자가 일반 사용자의 오남용을 방지하기 위해 이를 검증하는 코드도 작성하였습니다.

## 주요 변경 사항

- 익명 제보 요청/응답 DTO 추가
- 익명 제보 Repository 구현
- 익명 제보 서비스 로직 구현
   - 화장실 제보 등록
   - 본인 제보 조회
   - 단건 제보 조회
   - 제보 상태별 전체 조회 (관리자)
   - 제보 삭제 (본인 + PENDING 상태만 삭제 가능)
- 익명 제보 API 추가
   -  POST /api/v1/reports
   - GET /api/v1/reports/my?deviceId=xxx
   - GET /api/v1/reports/{reportId}
   - DELETE /api/v1/reports/{reportId}?deviceId=xxx
   - GET /api/v1/reports/admin?status=PENDING
   - PATCH /api/v1/reports/{reportId}/approve
   - PATCH /api/v1/reports/{reportId}/reject

## 구성된 파일

- domain/
    - ToiletReport.java
    
- dto/
    - request/ToiletReportRequest.java
    - response/ToiletReportResponse.java

- repository
    - ToiletReportRepository.java

- service
    - ToiletReportService.java

- controller
    - ToiletReportController.java

## 구현목적
- 공공 데이터로 얻어진 공중 화장실 정보가 부정확 할 수 있어, 이에 대한 제보를 받을 수 있다.
- 추가적인 화장실 존재 여부를 제공받을 수 있다.

## 이후 예정 작업
- 테스트 코드 작성
