### PR TITLE
feat(report): 제보 전체 목록 조회 API 추가(#17)

### DIFF
--- a/src/main/java/com/daeddong/controller/ToiletReportController.java
+++ b/src/main/java/com/daeddong/controller/ToiletReportController.java
@@ -45,6 +45,17 @@ public class ToiletReportController {
     }
 
     /**
+     * 전체 제보 목록 (게시판용)
+     * GET /api/v1/reports?page=0&size=20&sort=createdAt,desc
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<ToiletReportResponse>>> getReports(
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(reportService.getReports(pageable)));
+    }
+
+    /**
      * 내 제보 목록
      * GET /api/v1/reports/my?deviceId=xxx
      */

--- a/src/main/java/com/daeddong/service/ToiletReportService.java
+++ b/src/main/java/com/daeddong/service/ToiletReportService.java
@@ -50,6 +50,12 @@ public class ToiletReportService {
         return ToiletReportResponse.from(reportRepository.save(report));
     }
 
+    // ToiletReportService.java
+    public Page<ToiletReportResponse> getReports(Pageable pageable) {
+        return reportRepository.findAll(pageable)
+                .map(ToiletReportResponse::from);
+    }
+
     /** 본인 제보 목록 */
     public Page<ToiletReportResponse> getMyReports(String deviceId, Pageable pageable) {
         return reportRepository.findByDeviceIdOrderByCreatedAtDesc(deviceId, pageable)


### PR DESCRIPTION
제보 게시판에서 사용할 수 있는 전체 제보 목록 조회 API를 추가했습니다.  
페이징 및 정렬을 지원하여 최신순 기준으로 제보 데이터를 조회할 수 있습니다.

## 주요 변경 사항
- 제보 전체 목록 조회 API 추가
- 서비스 로직 추가

## 구성된 파일
- controller/
  - ToiletReportController.java (수정)

- service/
  - ToiletReportService.java (수정)

## 구현 목적
- 제보 게시판 UI에서 전체 제보 목록을 조회할 수 있도록 지원
- 페이징 기반 데이터 조회로 성능 및 확장성 확보

## 이후 예정 작업
- 상태별 필터링 (PENDING / APPROVED / REJECTED)
- 검색 기능 (이름, 주소 기반)