### PR TITLE
chore(swagger): Swagger 기반 API 문서화(#21)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 
     // AWS S3
     implementation 'software.amazon.awssdk:s3:2.25.60'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }
 
 def querydslDir = "src/main/generated"

--- a/src/main/java/com/daeddong/controller/CrowdVoteController.java
+++ b/src/main/java/com/daeddong/controller/CrowdVoteController.java
@@ -4,11 +4,15 @@ import com.daeddong.dto.request.CrowdVoteRequest;
 import com.daeddong.dto.response.CrowdVoteResponse;
 import com.daeddong.global.response.ApiResponse;
 import com.daeddong.service.CrowdVoteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "혼잡도", description = "화장실 혼잡도 투표 API")
 @RestController
 @RequestMapping("/api/v1/toilets/{toiletId}/crowd")
 @RequiredArgsConstructor
@@ -16,9 +20,16 @@ public class CrowdVoteController {
 
     private final CrowdVoteService crowdVoteService;
 
+    @Operation(summary = "혼잡도 투표",
+            description = """
+                    화장실 혼잡도를 투표합니다. (CROWDED / NORMAL / EMPTY)
+                    
+                    동일 기기가 동일 화장실에 이미 투표한 경우 기존 투표를 갱신(upsert)합니다.
+                    투표는 설정된 시간(기본 10분) 후 만료됩니다.
+                    """)
     @PostMapping
     public ResponseEntity<ApiResponse<CrowdVoteResponse>> vote(
-            @PathVariable Long toiletId,
+            @Parameter(description = "화장실 ID") @PathVariable Long toiletId,
             @RequestBody @Valid CrowdVoteRequest request
     ) {
         return ResponseEntity.ok(

--- a/src/main/java/com/daeddong/controller/ReviewController.java
+++ b/src/main/java/com/daeddong/controller/ReviewController.java
@@ -4,6 +4,9 @@ import com.daeddong.dto.request.ReviewRequest;
 import com.daeddong.dto.response.ReviewResponse;
 import com.daeddong.global.response.ApiResponse;
 import com.daeddong.service.ReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +21,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "리뷰", description = "화장실 리뷰 API")
 @RestController
 @RequestMapping("/api/v1/toilets/{toiletId}/reviews")
 @RequiredArgsConstructor
@@ -26,15 +30,11 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    /**
-     * 리뷰 등록
-     * Content-Type: multipart/form-data
-     * - data: ReviewRequest JSON 파트 (application/json)
-     * - image: 이미지 파일 (optional)
-     */
+    @Operation(summary = "리뷰 등록",
+            description = "화장실에 리뷰를 등록합니다. 기기당 화장실 1개 리뷰 제한. multipart/form-data: data(JSON) + image(파일, 선택)")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<ReviewResponse>> createReview(
-            @PathVariable Long toiletId,
+            @Parameter(description = "화장실 ID") @PathVariable Long toiletId,
             @RequestPart("data") @Valid ReviewRequest request,
             @RequestPart(value = "image", required = false) MultipartFile image
     ) {
@@ -42,19 +42,21 @@ public class ReviewController {
                 .body(ApiResponse.ok("리뷰가 등록되었습니다.", reviewService.createReview(toiletId, request, image)));
     }
 
+    @Operation(summary = "리뷰 목록 조회", description = "화장실 리뷰 목록을 최신순 페이지네이션으로 반환합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<ReviewResponse>>> getReviews(
-            @PathVariable Long toiletId,
+            @Parameter(description = "화장실 ID") @PathVariable Long toiletId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(ApiResponse.ok(reviewService.getReviews(toiletId, pageable)));
     }
 
+    @Operation(summary = "리뷰 삭제", description = "본인(deviceId 일치)이 작성한 리뷰만 삭제 가능합니다.")
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<ApiResponse<Void>> deleteReview(
-            @PathVariable Long toiletId,
-            @PathVariable Long reviewId,
-            @RequestParam @NotBlank String deviceId
+            @Parameter(description = "화장실 ID") @PathVariable Long toiletId,
+            @Parameter(description = "리뷰 ID") @PathVariable Long reviewId,
+            @Parameter(description = "기기 고유 ID") @RequestParam @NotBlank String deviceId
     ) {
         reviewService.deleteReview(toiletId, reviewId, deviceId);
         return ResponseEntity.ok(ApiResponse.ok("리뷰가 삭제되었습니다."));

--- a/src/main/java/com/daeddong/controller/ToiletController.java
+++ b/src/main/java/com/daeddong/controller/ToiletController.java
@@ -5,6 +5,9 @@ import com.daeddong.dto.response.ToiletDetailResponse;
 import com.daeddong.dto.response.ToiletSummaryResponse;
 import com.daeddong.global.response.ApiResponse;
 import com.daeddong.service.ToiletService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
@@ -12,8 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
+@Tag(name = "화장실", description = "화장실 조회 API")
 @RestController
 @RequestMapping("/api/v1/toilets")
 @RequiredArgsConstructor
@@ -22,29 +27,37 @@ public class ToiletController {
 
     private final ToiletService toiletService;
 
+    @Operation(summary = "반경 내 화장실 목록 조회",
+            description = "현재 위치(lat, lng) 기준 반경(radius) 내 화장실 목록을 거리순으로 반환합니다.")
     @GetMapping("/nearby")
     public ResponseEntity<ApiResponse<List<ToiletSummaryResponse>>> getNearby(
-            @RequestParam @NotNull @DecimalMin("-90.0") @DecimalMax("90.0") Double lat,
-            @RequestParam @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") Double lng,
-            @RequestParam(defaultValue = "1000") double radius,
-            @RequestParam(required = false) String openStatus,
-            @RequestParam(required = false) Boolean isDisabled
+            @Parameter(description = "위도 (-90.0 ~ 90.0)", example = "37.5665") @RequestParam @NotNull @DecimalMin("-90.0") @DecimalMax("90.0") Double lat,
+            @Parameter(description = "경도 (-180.0 ~ 180.0)", example = "126.9780") @RequestParam @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") Double lng,
+            @Parameter(description = "반경 (미터, 100~5000)", example = "1000") @RequestParam(defaultValue = "1000") double radius,
+            @Parameter(description = "운영 상태 필터 (OPEN / NIGHT / CLOSED)") @RequestParam(required = false) String openStatus,
+            @Parameter(description = "장애인 화장실만 조회") @RequestParam(required = false) Boolean isDisabled
     ) {
         ToiletNearbyRequest request = new ToiletNearbyRequest();
         request.init(lat, lng, radius, openStatus, isDisabled);
         return ResponseEntity.ok(ApiResponse.ok(toiletService.findNearby(request)));
     }
 
+    @Operation(summary = "가장 가까운 화장실 조회",
+            description = "현재 위치 기준 5km 이내에서 가장 가까운 화장실 1건을 반환합니다.")
     @GetMapping("/nearest")
     public ResponseEntity<ApiResponse<ToiletSummaryResponse>> getNearest(
-            @RequestParam @NotNull @DecimalMin("-90.0") @DecimalMax("90.0") Double lat,
-            @RequestParam @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") Double lng
+            @Parameter(description = "위도", example = "37.5665") @RequestParam @NotNull @DecimalMin("-90.0") @DecimalMax("90.0") Double lat,
+            @Parameter(description = "경도", example = "126.9780") @RequestParam @NotNull @DecimalMin("-180.0") @DecimalMax("180.0") Double lng
     ) {
         return ResponseEntity.ok(ApiResponse.ok(toiletService.findNearest(lat, lng)));
     }
 
+    @Operation(summary = "화장실 상세 조회",
+            description = "화장실 상세 정보 + 실시간 혼잡도 집계 + 평균 별점 + 리뷰 수를 반환합니다.")
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<ToiletDetailResponse>> getDetail(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<ToiletDetailResponse>> getDetail(
+            @Parameter(description = "화장실 ID") @PathVariable Long id
+    ) {
         return ResponseEntity.ok(ApiResponse.ok(toiletService.findDetail(id)));
     }
 }

--- a/src/main/java/com/daeddong/controller/ToiletReportController.java
+++ b/src/main/java/com/daeddong/controller/ToiletReportController.java
@@ -5,6 +5,9 @@ import com.daeddong.dto.request.ToiletReportRequest;
 import com.daeddong.dto.response.ToiletReportResponse;
 import com.daeddong.global.response.ApiResponse;
 import com.daeddong.service.ToiletReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "제보", description = "화장실 제보 API")
 @RestController
 @RequestMapping("/api/v1/reports")
 @RequiredArgsConstructor
@@ -27,13 +31,8 @@ public class ToiletReportController {
 
     private final ToiletReportService reportService;
 
-    /**
-     * 화장실 제보 등록
-     * POST /api/v1/reports
-     * Content-Type: multipart/form-data
-     * - data: ToiletReportRequest JSON (필수/선택 필드 포함)
-     * - image: 현장 사진 (optional)
-     */
+    @Operation(summary = "제보 등록",
+            description = "새 화장실 위치를 익명으로 제보합니다. multipart/form-data: data(JSON) + image(파일, 선택)")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<ToiletReportResponse>> createReport(
             @RequestPart("data") @Valid ToiletReportRequest request,
@@ -44,10 +43,7 @@ public class ToiletReportController {
                         reportService.createReport(request, image)));
     }
 
-    /**
-     * 전체 제보 목록 (게시판용)
-     * GET /api/v1/reports?page=0&size=20&sort=createdAt,desc
-     */
+    @Operation(summary = "전체 제보 목록 조회", description = "게시판 형태로 전체 제보 목록을 페이지네이션으로 반환합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<ToiletReportResponse>>> getReports(
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
@@ -55,37 +51,28 @@ public class ToiletReportController {
         return ResponseEntity.ok(ApiResponse.ok(reportService.getReports(pageable)));
     }
 
-    /**
-     * 내 제보 목록
-     * GET /api/v1/reports/my?deviceId=xxx
-     */
+    @Operation(summary = "내 제보 목록 조회", description = "deviceId 기준 내가 제보한 목록을 반환합니다.")
     @GetMapping("/my")
     public ResponseEntity<ApiResponse<Page<ToiletReportResponse>>> getMyReports(
-            @RequestParam @NotBlank String deviceId,
+            @Parameter(description = "기기 고유 ID") @RequestParam @NotBlank String deviceId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(ApiResponse.ok(reportService.getMyReports(deviceId, pageable)));
     }
 
-    /**
-     * 제보 단건 조회
-     * GET /api/v1/reports/{reportId}
-     */
+    @Operation(summary = "제보 단건 조회")
     @GetMapping("/{reportId}")
     public ResponseEntity<ApiResponse<ToiletReportResponse>> getReport(
-            @PathVariable Long reportId
+            @Parameter(description = "제보 ID") @PathVariable Long reportId
     ) {
         return ResponseEntity.ok(ApiResponse.ok(reportService.getReport(reportId)));
     }
 
-    /**
-     * 제보 삭제 (본인 + PENDING 상태만)
-     * DELETE /api/v1/reports/{reportId}?deviceId=xxx
-     */
+    @Operation(summary = "제보 삭제", description = "본인(deviceId 일치) + PENDING 상태인 제보만 삭제 가능합니다.")
     @DeleteMapping("/{reportId}")
     public ResponseEntity<ApiResponse<Void>> deleteReport(
-            @PathVariable Long reportId,
-            @RequestParam @NotBlank String deviceId
+            @Parameter(description = "제보 ID") @PathVariable Long reportId,
+            @Parameter(description = "기기 고유 ID") @RequestParam @NotBlank String deviceId
     ) {
         reportService.deleteReport(reportId, deviceId);
         return ResponseEntity.ok(ApiResponse.ok("제보가 삭제되었습니다."));
@@ -93,38 +80,29 @@ public class ToiletReportController {
 
     // ── 관리자 ────────────────────────────────────────────
 
-    /**
-     * 상태별 제보 목록 (관리자)
-     * GET /api/v1/reports/admin?status=PENDING
-     */
+    @Operation(summary = "[관리자] 상태별 제보 목록 조회", description = "status 파라미터로 PENDING / APPROVED / REJECTED 필터링")
     @GetMapping("/admin")
     public ResponseEntity<ApiResponse<Page<ToiletReportResponse>>> getReportsByStatus(
-            @RequestParam(defaultValue = "PENDING") ReportStatus status,
+            @Parameter(description = "처리 상태") @RequestParam(defaultValue = "PENDING") ReportStatus status,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity.ok(ApiResponse.ok(reportService.getReportsByStatus(status, pageable)));
     }
 
-    /**
-     * 제보 승인 → 화장실 자동 등록 (관리자)
-     * PATCH /api/v1/reports/{reportId}/approve
-     */
+    @Operation(summary = "[관리자] 제보 승인", description = "제보를 승인하면 화장실이 지도에 자동 등록됩니다.")
     @PatchMapping("/{reportId}/approve")
     public ResponseEntity<ApiResponse<ToiletReportResponse>> approveReport(
-            @PathVariable Long reportId
+            @Parameter(description = "제보 ID") @PathVariable Long reportId
     ) {
         return ResponseEntity.ok(ApiResponse.ok(
                 "제보가 승인되어 화장실이 지도에 등록되었습니다.",
                 reportService.approveReport(reportId)));
     }
 
-    /**
-     * 제보 반려 (관리자)
-     * PATCH /api/v1/reports/{reportId}/reject
-     */
+    @Operation(summary = "[관리자] 제보 반려")
     @PatchMapping("/{reportId}/reject")
     public ResponseEntity<ApiResponse<ToiletReportResponse>> rejectReport(
-            @PathVariable Long reportId
+            @Parameter(description = "제보 ID") @PathVariable Long reportId
     ) {
         return ResponseEntity.ok(ApiResponse.ok("제보가 반려되었습니다.",
                 reportService.rejectReport(reportId)));

--- a/src/main/java/com/daeddong/global/config/SwaggerConfig.java
+++ b/src/main/java/com/daeddong/global/config/SwaggerConfig.java
@@ -1,4 +1,34 @@
 package com.daeddong.global.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
 public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("대똥여지도 API")
+                        .description("""
+                                공용화장실 위치 기반 모바일 서비스 백엔드 API
+                                
+                                **인증**: 로그인 없이 deviceId(기기 고유 ID)로 사용자 식별
+                                
+                                **이미지 업로드**: multipart/form-data — data 파트(JSON) + image 파트(파일)
+                                """)
+                        .version("v1")
+                        .contact(new Contact().name("대똥여지도 팀")))
+                .servers(List.of(
+                        new Server().url("http://localhost:8080").description("로컬 서버"),
+                        new Server().url("https://api.daeddong.com").description("운영 서버")
+                ));
+    }
 }

--- a/src/main/java/com/daeddong/global/config/SwaggerConfig.java
+++ b/src/main/java/com/daeddong/global/config/SwaggerConfig.java
@@ -1,0 +1,4 @@
+package com.daeddong.global.config;
+
+public class SwaggerConfig {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,11 @@ cloud:
     credentials:
       access-key: ${AWS_ACCESS_KEY}
       secret-key: ${AWS_SECRET_KEY}
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /api-docs


### PR DESCRIPTION
Swagger 기반 API 문서화를 적용하고, 주요 컨트롤러에 문서 어노테이션을 추가했습니다.  
또한 API 설명 및 파라미터 명세를 보강하여 프론트 및 협업 시 가독성과 사용성을 개선했습니다.

---

## 주요 변경 사항
- Swagger(OpenAPI) 설정 추가
- Swagger UI 설정 추가
- Controller 전반에 Swagger 어노테이션 적용
- API 명세 보강

---

## 구성된 파일
- `src/main/java/com/daeddong/global/config/SwaggerConfig.java`
- `src/main/java/com/daeddong/controller/CrowdVoteController.java`
- `src/main/java/com/daeddong/controller/ReviewController.java`
- `src/main/java/com/daeddong/controller/ToiletController.java`
- `src/main/java/com/daeddong/controller/ToiletReportController.java`
- `src/main/resources/application.yml`
- `build.gradle`

---

## 구현 목적
- API 명세를 시각적으로 제공하여 개발 및 협업 효율 향상
- 프론트엔드 및 외부 개발자의 API 이해도 개선
- 요청/응답 구조를 명확히 하여 유지보수성 강화

---

## 이후 예정 작업
- Swagger 예시 요청/응답 데이터 추가
- 인증/에러 코드 문서화 확장
- API 버전 관리 전략 정립