### PR TITLE
feat(paper) : Fcm 토큰, 휴지요청 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
 }
 
 def querydslDir = "src/main/generated"

--- a/src/main/java/com/daeddong/controller/PaperRequestController.java
+++ b/src/main/java/com/daeddong/controller/PaperRequestController.java
@@ -1,0 +1,82 @@
+package com.daeddong.controller;
+
+import com.daeddong.dto.request.PaperRequestCreateRequest;
+import com.daeddong.dto.response.ActivePaperRequestResponse;
+import com.daeddong.dto.response.PaperRequestResponse;
+import com.daeddong.global.response.ApiResponse;
+import com.daeddong.service.PaperRequestService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "휴지 요청", description = "긴급 휴지 요청 API 🧻")
+@RestController
+@RequestMapping("/api/v1/paper-requests")
+@RequiredArgsConstructor
+@Validated
+public class PaperRequestController {
+
+    private final PaperRequestService paperRequestService;
+
+    @Operation(summary = "휴지 요청 생성",
+            description = "500m 이내 화장실에서만 가능. 하루 1회 제한.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<PaperRequestResponse>> createRequest(
+            @Valid @RequestBody PaperRequestCreateRequest request) {
+        return ResponseEntity.ok(
+                ApiResponse.ok("휴지 요청이 등록되었습니다.", paperRequestService.createRequest(request)));
+    }
+
+    @Operation(summary = "구조 완료 (살았습니다! 버튼)",
+            description = "요청자 본인만 가능. 완료 후 3분간 *구조* 마커 표시.")
+    @PostMapping("/{requestId}/rescue")
+    public ResponseEntity<ApiResponse<PaperRequestResponse>> rescue(
+            @Parameter(description = "요청 ID") @PathVariable Long requestId,
+            @Parameter(description = "기기 ID") @RequestParam @NotBlank String deviceId) {
+        return ResponseEntity.ok(
+                ApiResponse.ok("구조 완료! 정말 다행입니다 😊", paperRequestService.rescue(requestId, deviceId)));
+    }
+
+    @Operation(summary = "지도 마커용 활성 요청 목록",
+            description = "PAPER_FLYING(휴지 분수) + RESCUED(*구조*) 마커. 10초 폴링 권장.")
+    @GetMapping("/active-markers")
+    public ResponseEntity<ApiResponse<List<ActivePaperRequestResponse>>> getActiveMarkers() {
+        return ResponseEntity.ok(ApiResponse.ok(paperRequestService.getActiveMarkers()));
+    }
+
+    @Operation(summary = "특정 화장실 활성 요청 조회", description = "마커 클릭 시 상세 정보.")
+    @GetMapping("/toilet/{toiletId}")
+    public ResponseEntity<ApiResponse<PaperRequestResponse>> getActiveByToilet(
+            @Parameter(description = "화장실 ID") @PathVariable Long toiletId) {
+        return ResponseEntity.ok(ApiResponse.ok(paperRequestService.getActiveByToilet(toiletId)));
+    }
+
+    @Operation(summary = "내 요청 상태 조회",
+            description = "요청자가 남은 시간(remainingSeconds) 및 상태 확인. 7초 폴링 권장.")
+    @GetMapping("/{requestId}/status")
+    public ResponseEntity<ApiResponse<PaperRequestResponse>> getStatus(
+            @Parameter(description = "요청 ID") @PathVariable Long requestId,
+            @Parameter(description = "기기 ID") @RequestParam @NotBlank String deviceId) {
+        return ResponseEntity.ok(ApiResponse.ok(paperRequestService.getRequestStatus(requestId, deviceId)));
+    }
+
+    @Operation(summary = "FCM 토큰 등록/갱신",
+            description = "앱 시작 시 또는 위치 변경 시 호출. 주변 알림 수신에 필요.")
+    @PostMapping("/fcm-token")
+    public ResponseEntity<ApiResponse<Void>> registerFcmToken(
+            @Parameter(description = "기기 ID") @RequestParam @NotBlank String deviceId,
+            @Parameter(description = "FCM 토큰") @RequestParam @NotBlank String fcmToken,
+            @Parameter(description = "현재 위도") @RequestParam Double lat,
+            @Parameter(description = "현재 경도") @RequestParam Double lng) {
+        paperRequestService.registerFcmToken(deviceId, fcmToken, lat, lng);
+        return ResponseEntity.ok(ApiResponse.ok("FCM 토큰이 등록되었습니다."));
+    }
+}

--- a/src/main/java/com/daeddong/domain/FcmToken.java
+++ b/src/main/java/com/daeddong/domain/FcmToken.java
@@ -1,0 +1,53 @@
+package com.daeddong.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "fcm_tokens",
+        uniqueConstraints = @UniqueConstraint(columnNames = "device_id"))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "device_id", nullable = false, length = 100, unique = true)
+    private String deviceId;
+
+    @Column(name = "fcm_token", nullable = false, length = 500)
+    private String fcmToken;
+
+    @Column(name = "last_lat")
+    private Double lastLat;
+
+    @Column(name = "last_lng")
+    private Double lastLng;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public static FcmToken create(String deviceId, String fcmToken, Double lat, Double lng) {
+        FcmToken t = new FcmToken();
+        t.deviceId = deviceId;
+        t.fcmToken = fcmToken;
+        t.lastLat = lat;
+        t.lastLng = lng;
+        return t;
+    }
+
+    public void update(String fcmToken, Double lat, Double lng) {
+        this.fcmToken = fcmToken;
+        this.lastLat = lat;
+        this.lastLng = lng;
+    }
+}

--- a/src/main/java/com/daeddong/domain/PaperRequest.java
+++ b/src/main/java/com/daeddong/domain/PaperRequest.java
@@ -1,0 +1,85 @@
+package com.daeddong.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "paper_requests")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaperRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "toilet_id", nullable = false)
+    private Toilet toilet;
+
+    @Column(name = "device_id", nullable = false, length = 100)
+    private String deviceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private RequestStatus status;
+
+    @Column(name = "requested_at", nullable = false)
+    private LocalDateTime requestedAt;
+
+    /** 요청 만료 시각 (요청 후 7분) */
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "rescued_at")
+    private LocalDateTime rescuedAt;
+
+    /** 구조 완료 후 *구조* 마커 표시 종료 시각 (구조 후 3분) */
+    @Column(name = "rescue_display_until")
+    private LocalDateTime rescueDisplayUntil;
+
+    private static final int EXPIRE_MINUTES = 7;
+    private static final int RESCUE_DISPLAY_MINUTES = 3;
+
+    public static PaperRequest create(Toilet toilet, String deviceId, Gender gender) {
+        PaperRequest r = new PaperRequest();
+        r.toilet = toilet;
+        r.deviceId = deviceId;
+        r.gender = gender;
+        r.requestedAt = LocalDateTime.now();
+        r.expiresAt = r.requestedAt.plusMinutes(EXPIRE_MINUTES);
+        r.status = RequestStatus.ACTIVE;
+        return r;
+    }
+
+    public void rescue() {
+        this.status = RequestStatus.RESCUED;
+        this.rescuedAt = LocalDateTime.now();
+        this.rescueDisplayUntil = this.rescuedAt.plusMinutes(RESCUE_DISPLAY_MINUTES);
+    }
+
+    public boolean isActive(LocalDateTime now) {
+        return this.status == RequestStatus.ACTIVE && now.isBefore(this.expiresAt);
+    }
+
+    public boolean isRescueDisplaying(LocalDateTime now) {
+        return this.status == RequestStatus.RESCUED
+                && this.rescueDisplayUntil != null
+                && now.isBefore(this.rescueDisplayUntil);
+    }
+
+    public enum Gender {
+        MALE, FEMALE
+    }
+
+    public enum RequestStatus {
+        ACTIVE,   // 요청 중 (7분간)
+        RESCUED,  // 구조 완료
+        EXPIRED   // 시간 초과 종료
+    }
+}

--- a/src/main/java/com/daeddong/dto/request/PaperRequestCreateRequest.java
+++ b/src/main/java/com/daeddong/dto/request/PaperRequestCreateRequest.java
@@ -1,0 +1,31 @@
+package com.daeddong.dto.request;
+
+import com.daeddong.domain.PaperRequest;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PaperRequestCreateRequest {
+
+    @NotNull(message = "화장실 ID는 필수입니다.")
+    private Long toiletId;
+
+    @NotBlank(message = "기기 ID는 필수입니다.")
+    @Size(max = 100)
+    private String deviceId;
+
+    @NotNull(message = "성별 선택은 필수입니다. (MALE / FEMALE)")
+    private PaperRequest.Gender gender;
+
+    @NotNull(message = "위도는 필수입니다.")
+    @DecimalMin("-90.0")
+    @DecimalMax("90.0")
+    private Double lat;
+
+    @NotNull(message = "경도는 필수입니다.")
+    @DecimalMin("-180.0")
+    @DecimalMax("180.0")
+    private Double lng;
+}

--- a/src/main/java/com/daeddong/dto/response/ActivePaperRequestResponse.java
+++ b/src/main/java/com/daeddong/dto/response/ActivePaperRequestResponse.java
@@ -1,0 +1,69 @@
+package com.daeddong.dto.response;
+
+import com.daeddong.domain.PaperRequest;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * 지도 마커 표시용 응답 DTO.
+ * 플러터 클라이언트가 /active-markers 를 10초마다 폴링.
+ */
+@Getter
+@Builder
+public class ActivePaperRequestResponse {
+
+    private Long requestId;
+    private Long toiletId;
+    private Double toiletLat;
+    private Double toiletLng;
+
+    /**
+     * PAPER_FLYING : 휴지 분수 애니메이션 (ACTIVE 7분간)
+     * RESCUED      : *구조* 텍스트 (구조 완료 후 3분간)
+     */
+    private MarkerDisplayType displayType;
+
+    private PaperRequest.Gender gender;
+    private LocalDateTime expiresAt;
+    private LocalDateTime rescueDisplayUntil;
+    private long remainingSeconds;
+
+    public static ActivePaperRequestResponse fromActive(PaperRequest pr) {
+        LocalDateTime now = LocalDateTime.now();
+        long remaining = Duration.between(now, pr.getExpiresAt()).getSeconds();
+        return ActivePaperRequestResponse.builder()
+                .requestId(pr.getId())
+                .toiletId(pr.getToilet().getId())
+                .toiletLat(pr.getToilet().getLat())
+                .toiletLng(pr.getToilet().getLng())
+                .displayType(MarkerDisplayType.PAPER_FLYING)
+                .gender(pr.getGender())
+                .expiresAt(pr.getExpiresAt())
+                .rescueDisplayUntil(null)
+                .remainingSeconds(Math.max(remaining, 0))
+                .build();
+    }
+
+    public static ActivePaperRequestResponse fromRescued(PaperRequest pr) {
+        LocalDateTime now = LocalDateTime.now();
+        long remaining = Duration.between(now, pr.getRescueDisplayUntil()).getSeconds();
+        return ActivePaperRequestResponse.builder()
+                .requestId(pr.getId())
+                .toiletId(pr.getToilet().getId())
+                .toiletLat(pr.getToilet().getLat())
+                .toiletLng(pr.getToilet().getLng())
+                .displayType(MarkerDisplayType.RESCUED)
+                .gender(pr.getGender())
+                .expiresAt(pr.getExpiresAt())
+                .rescueDisplayUntil(pr.getRescueDisplayUntil())
+                .remainingSeconds(Math.max(remaining, 0))
+                .build();
+    }
+
+    public enum MarkerDisplayType {
+        PAPER_FLYING,
+        RESCUED
+    }
+}

--- a/src/main/java/com/daeddong/dto/response/PaperRequestResponse.java
+++ b/src/main/java/com/daeddong/dto/response/PaperRequestResponse.java
@@ -1,0 +1,51 @@
+package com.daeddong.dto.response;
+
+import com.daeddong.domain.PaperRequest;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PaperRequestResponse {
+
+    private Long id;
+    private Long toiletId;
+    private String toiletName;
+    private Double toiletLat;
+    private Double toiletLng;
+    private String deviceId;
+    private PaperRequest.Gender gender;
+    private PaperRequest.RequestStatus status;
+    private LocalDateTime requestedAt;
+    private LocalDateTime expiresAt;
+    private LocalDateTime rescuedAt;
+    private LocalDateTime rescueDisplayUntil;
+    /** 남은 활성 시간(초). ACTIVE 상태일 때만 의미 있음 */
+    private long remainingSeconds;
+
+    public static PaperRequestResponse from(PaperRequest pr) {
+        LocalDateTime now = LocalDateTime.now();
+        long remaining = 0;
+        if (pr.getStatus() == PaperRequest.RequestStatus.ACTIVE) {
+            remaining = Duration.between(now, pr.getExpiresAt()).getSeconds();
+            if (remaining < 0) remaining = 0;
+        }
+        return PaperRequestResponse.builder()
+                .id(pr.getId())
+                .toiletId(pr.getToilet().getId())
+                .toiletName(pr.getToilet().getName())
+                .toiletLat(pr.getToilet().getLat())
+                .toiletLng(pr.getToilet().getLng())
+                .deviceId(pr.getDeviceId())
+                .gender(pr.getGender())
+                .status(pr.getStatus())
+                .requestedAt(pr.getRequestedAt())
+                .expiresAt(pr.getExpiresAt())
+                .rescuedAt(pr.getRescuedAt())
+                .rescueDisplayUntil(pr.getRescueDisplayUntil())
+                .remainingSeconds(remaining)
+                .build();
+    }
+}

--- a/src/main/java/com/daeddong/global/config/FirebaseConfig.java
+++ b/src/main/java/com/daeddong/global/config/FirebaseConfig.java
@@ -1,0 +1,41 @@
+package com.daeddong.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.service-account-path:firebase-service-account.json}")
+    private String serviceAccountPath;
+
+    @PostConstruct
+    public void initialize() {
+        try {
+            if (!FirebaseApp.getApps().isEmpty()) {
+                log.info("[Firebase] 이미 초기화됨 - 생략");
+                return;
+            }
+            InputStream serviceAccount =
+                    new ClassPathResource(serviceAccountPath).getInputStream();
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            FirebaseApp.initializeApp(options);
+            log.info("[Firebase] Admin SDK 초기화 완료");
+        } catch (IOException e) {
+            // JSON 파일 없으면 FCM만 비활성화, 앱 전체 중단 방지
+            log.error("[Firebase] 초기화 실패 - 파일 확인 필요: {}", serviceAccountPath, e);
+        }
+    }
+}

--- a/src/main/java/com/daeddong/global/exception/ErrorCode.java
+++ b/src/main/java/com/daeddong/global/exception/ErrorCode.java
@@ -25,7 +25,14 @@ public enum ErrorCode {
     // 제보
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "제보를 찾을 수 없습니다."),
     REPORT_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 작성한 제보만 삭제할 수 있습니다."),
-    REPORT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 제보입니다.");
+    REPORT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 제보입니다."),
+
+    // 휴지 요청
+    PAPER_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "휴지 요청을 찾을 수 없습니다."),
+    PAPER_REQUEST_TOO_FAR(HttpStatus.BAD_REQUEST, "화장실로부터 500m 이내에서만 휴지 요청이 가능합니다."),
+    PAPER_REQUEST_DAILY_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "휴지 요청은 하루에 한 번만 사용할 수 있습니다. 정말 긴급한 상황인가요?!?"),
+    PAPER_REQUEST_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "이미 종료되었거나 만료된 휴지 요청입니다."),
+    PAPER_REQUEST_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 요청한 건만 처리할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/daeddong/repository/FcmTokenRepository.java
+++ b/src/main/java/com/daeddong/repository/FcmTokenRepository.java
@@ -1,0 +1,33 @@
+package com.daeddong.repository;
+
+import com.daeddong.domain.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    Optional<FcmToken> findByDeviceId(String deviceId);
+
+    /** 반경 radiusMeters 내 FCM 토큰 목록. 요청자 본인 제외. */
+    @Query(value = """
+            SELECT ft.fcm_token
+            FROM fcm_tokens ft
+            WHERE ft.device_id != :excludeDeviceId
+              AND ft.last_lat IS NOT NULL
+              AND ft.last_lng IS NOT NULL
+              AND ST_Distance_Sphere(
+                    POINT(ft.last_lng, ft.last_lat),
+                    POINT(:lng, :lat)
+                  ) <= :radiusMeters
+            """, nativeQuery = true)
+    List<String> findNearbyTokens(
+            @Param("lat") Double lat,
+            @Param("lng") Double lng,
+            @Param("radiusMeters") double radiusMeters,
+            @Param("excludeDeviceId") String excludeDeviceId
+    );
+}

--- a/src/main/java/com/daeddong/repository/PaperRequestRepository.java
+++ b/src/main/java/com/daeddong/repository/PaperRequestRepository.java
@@ -1,0 +1,74 @@
+package com.daeddong.repository;
+
+import com.daeddong.domain.PaperRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaperRequestRepository extends JpaRepository<PaperRequest, Long> {
+
+    /** 하루 1회 제한: 오늘 이미 요청했는지 확인 */
+    @Query("""
+            SELECT COUNT(pr) > 0 FROM PaperRequest pr
+            WHERE pr.deviceId = :deviceId
+              AND pr.requestedAt >= :startOfDay
+              AND pr.requestedAt < :endOfDay
+            """)
+    boolean existsTodayRequest(
+            @Param("deviceId") String deviceId,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+
+    /** 지도 마커용: 현재 ACTIVE 상태 전체 */
+    @Query("""
+            SELECT pr FROM PaperRequest pr
+            JOIN FETCH pr.toilet t
+            WHERE pr.status = 'ACTIVE'
+              AND pr.expiresAt > :now
+            """)
+    List<PaperRequest> findAllActive(@Param("now") LocalDateTime now);
+
+    /** 지도 마커용: RESCUED 상태 중 *구조* 표시 기간 내 */
+    @Query("""
+            SELECT pr FROM PaperRequest pr
+            JOIN FETCH pr.toilet t
+            WHERE pr.status = 'RESCUED'
+              AND pr.rescueDisplayUntil > :now
+            """)
+    List<PaperRequest> findAllRescueDisplaying(@Param("now") LocalDateTime now);
+
+    /** 특정 화장실의 현재 활성 요청 (최신 1개) */
+    @Query("""
+            SELECT pr FROM PaperRequest pr
+            JOIN FETCH pr.toilet t
+            WHERE pr.toilet.id = :toiletId
+              AND pr.status = 'ACTIVE'
+              AND pr.expiresAt > :now
+            ORDER BY pr.requestedAt DESC
+            """)
+    Optional<PaperRequest> findActiveByToiletId(
+            @Param("toiletId") Long toiletId,
+            @Param("now") LocalDateTime now
+    );
+
+    /** 본인 확인용 */
+    Optional<PaperRequest> findByIdAndDeviceId(Long id, String deviceId);
+
+    /** 스케줄러: 만료된 ACTIVE → EXPIRED 일괄 처리 */
+    @Modifying
+    @Transactional
+    @Query("""
+            UPDATE PaperRequest pr
+            SET pr.status = 'EXPIRED'
+            WHERE pr.status = 'ACTIVE'
+              AND pr.expiresAt <= :now
+            """)
+    int expireOldRequests(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/daeddong/service/FcmService.java
+++ b/src/main/java/com/daeddong/service/FcmService.java
@@ -1,0 +1,78 @@
+package com.daeddong.service;
+
+import com.google.firebase.messaging.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class FcmService {
+
+    /**
+     * 휴지 요청 긴급 알림 발송.
+     * 주변 1km 사용자에게 전송.
+     */
+    public void sendPaperRequestAlert(List<String> tokens, String toiletName) {
+        if (tokens == null || tokens.isEmpty()) {
+            log.debug("[FCM] 주변 수신자 없음 - 발송 생략");
+            return;
+        }
+
+        for (List<String> chunk : partition(tokens, 500)) {
+            MulticastMessage message = MulticastMessage.builder()
+                    .addAllTokens(chunk)
+                    .setNotification(Notification.builder()
+                            .setTitle("🧻 긴급 휴지 요청!")
+                            .setBody("일생일대의 급박한 사람을 도와주세요... 😭 (" + toiletName + ")")
+                            .build())
+                    .putData("type", "PAPER_REQUEST")
+                    .putData("toiletName", toiletName)
+                    .setAndroidConfig(AndroidConfig.builder()
+                            .setPriority(AndroidConfig.Priority.HIGH)
+                            .setNotification(AndroidNotification.builder()
+                                    .setSound("default")
+                                    .build())
+                            .build())
+                    .setApnsConfig(ApnsConfig.builder()
+                            .setAps(Aps.builder()
+                                    .setSound("default")
+                                    .setBadge(1)
+                                    .build())
+                            .build())
+                    .build();
+
+            try {
+                BatchResponse response = FirebaseMessaging.getInstance()
+                        .sendEachForMulticast(message);
+                log.info("[FCM] 발송 완료 - 성공: {}, 실패: {}",
+                        response.getSuccessCount(), response.getFailureCount());
+
+                if (response.getFailureCount() > 0) {
+                    List<SendResponse> responses = response.getResponses();
+                    for (int i = 0; i < responses.size(); i++) {
+                        if (!responses.get(i).isSuccessful()) {
+                            log.warn("[FCM] 발송 실패 - token={}, reason={}",
+                                    chunk.get(i),
+                                    responses.get(i).getException() != null
+                                            ? responses.get(i).getException().getMessage()
+                                            : "unknown");
+                        }
+                    }
+                }
+            } catch (FirebaseMessagingException e) {
+                log.error("[FCM] 발송 오류", e);
+            }
+        }
+    }
+
+    private <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> result = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            result.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/daeddong/service/PaperRequestService.java
+++ b/src/main/java/com/daeddong/service/PaperRequestService.java
@@ -1,0 +1,174 @@
+package com.daeddong.service;
+
+import com.daeddong.domain.FcmToken;
+import com.daeddong.domain.PaperRequest;
+import com.daeddong.domain.Toilet;
+import com.daeddong.dto.request.PaperRequestCreateRequest;
+import com.daeddong.dto.response.ActivePaperRequestResponse;
+import com.daeddong.dto.response.PaperRequestResponse;
+import com.daeddong.global.exception.DaeddongException;
+import com.daeddong.global.exception.ErrorCode;
+import com.daeddong.repository.FcmTokenRepository;
+import com.daeddong.repository.PaperRequestRepository;
+import com.daeddong.repository.ToiletRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaperRequestService {
+
+    private static final double MAX_DISTANCE_METERS = 500.0;
+    private static final double NOTIFY_RADIUS_METERS = 1000.0;
+
+    private final PaperRequestRepository paperRequestRepository;
+    private final ToiletRepository toiletRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final FcmService fcmService;
+
+    // ── 휴지 요청 생성 ──────────────────────────────
+
+    @Transactional
+    public PaperRequestResponse createRequest(PaperRequestCreateRequest req) {
+
+        // 1. 화장실 존재 확인
+        Toilet toilet = toiletRepository.findById(req.getToiletId())
+                .orElseThrow(() -> new DaeddongException(ErrorCode.TOILET_NOT_FOUND));
+
+        // 2. 500m 거리 검증
+        double distance = calculateDistance(
+                req.getLat(), req.getLng(), toilet.getLat(), toilet.getLng());
+        if (distance > MAX_DISTANCE_METERS) {
+            throw new DaeddongException(
+                    ErrorCode.PAPER_REQUEST_TOO_FAR,
+                    "화장실로부터 " + Math.round(distance) + "m 떨어져 있습니다. "
+                            + "500m 이내에서만 휴지 요청이 가능합니다.");
+        }
+
+        // 3. 하루 1회 제한
+        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfDay   = LocalDate.now().atTime(LocalTime.MAX);
+        if (paperRequestRepository.existsTodayRequest(req.getDeviceId(), startOfDay, endOfDay)) {
+            throw new DaeddongException(ErrorCode.PAPER_REQUEST_DAILY_LIMIT_EXCEEDED);
+        }
+
+        // 4. 저장
+        PaperRequest paperRequest = PaperRequest.create(toilet, req.getDeviceId(), req.getGender());
+        paperRequestRepository.save(paperRequest);
+        log.info("[PaperRequest] 생성 - id={}, toiletId={}, deviceId={}, gender={}",
+                paperRequest.getId(), toilet.getId(), req.getDeviceId(), req.getGender());
+
+        // 5. 주변 1km FCM 알림 (실패해도 요청은 정상 처리)
+        sendNearbyNotifications(req.getLat(), req.getLng(), req.getDeviceId(), toilet.getName());
+
+        return PaperRequestResponse.from(paperRequest);
+    }
+
+    // ── 구조 완료 ("살았습니다." 버튼) ───────────────
+
+    @Transactional
+    public PaperRequestResponse rescue(Long requestId, String deviceId) {
+        PaperRequest pr = paperRequestRepository.findByIdAndDeviceId(requestId, deviceId)
+                .orElseThrow(() -> new DaeddongException(ErrorCode.PAPER_REQUEST_NOT_FOUND));
+
+        if (!pr.isActive(LocalDateTime.now())) {
+            throw new DaeddongException(ErrorCode.PAPER_REQUEST_NOT_ACTIVE);
+        }
+
+        pr.rescue();
+        log.info("[PaperRequest] 구조 완료 - id={}, toiletId={}", requestId, pr.getToilet().getId());
+        return PaperRequestResponse.from(pr);
+    }
+
+    // ── 지도 마커 조회 ───────────────────────────────
+
+    /** 플러터에서 10초마다 폴링. PAPER_FLYING + RESCUED 마커 모두 반환 */
+    public List<ActivePaperRequestResponse> getActiveMarkers() {
+        LocalDateTime now = LocalDateTime.now();
+        List<ActivePaperRequestResponse> result = new ArrayList<>();
+
+        paperRequestRepository.findAllActive(now).stream()
+                .map(ActivePaperRequestResponse::fromActive)
+                .forEach(result::add);
+
+        paperRequestRepository.findAllRescueDisplaying(now).stream()
+                .map(ActivePaperRequestResponse::fromRescued)
+                .forEach(result::add);
+
+        return result;
+    }
+
+    /** 특정 화장실의 활성 요청 상세 (마커 클릭 시) */
+    public PaperRequestResponse getActiveByToilet(Long toiletId) {
+        return paperRequestRepository
+                .findActiveByToiletId(toiletId, LocalDateTime.now())
+                .map(PaperRequestResponse::from)
+                .orElseThrow(() -> new DaeddongException(
+                        ErrorCode.PAPER_REQUEST_NOT_FOUND, "현재 활성 휴지 요청이 없습니다."));
+    }
+
+    /** 요청자 본인 상태 폴링 (7초마다) */
+    public PaperRequestResponse getRequestStatus(Long requestId, String deviceId) {
+        return paperRequestRepository.findByIdAndDeviceId(requestId, deviceId)
+                .map(PaperRequestResponse::from)
+                .orElseThrow(() -> new DaeddongException(ErrorCode.PAPER_REQUEST_NOT_FOUND));
+    }
+
+    // ── FCM 토큰 등록/갱신 ───────────────────────────
+
+    @Transactional
+    public void registerFcmToken(String deviceId, String fcmToken, Double lat, Double lng) {
+        fcmTokenRepository.findByDeviceId(deviceId).ifPresentOrElse(
+                existing -> existing.update(fcmToken, lat, lng),
+                () -> fcmTokenRepository.save(FcmToken.create(deviceId, fcmToken, lat, lng))
+        );
+        log.debug("[FCM] 토큰 등록/갱신 - deviceId={}", deviceId);
+    }
+
+    // ── 스케줄러: 만료 처리 ──────────────────────────
+
+    @Scheduled(fixedDelay = 60_000)
+    @Transactional
+    public void expireOldRequests() {
+        int count = paperRequestRepository.expireOldRequests(LocalDateTime.now());
+        if (count > 0) log.info("[PaperRequest] 만료 처리 {}건", count);
+    }
+
+    // ── 내부 유틸 ────────────────────────────────────
+
+    private void sendNearbyNotifications(double lat, double lng,
+                                         String requesterDeviceId, String toiletName) {
+        try {
+            List<String> tokens = fcmTokenRepository.findNearbyTokens(
+                    lat, lng, NOTIFY_RADIUS_METERS, requesterDeviceId);
+            if (!tokens.isEmpty()) {
+                fcmService.sendPaperRequestAlert(tokens, toiletName);
+                log.info("[PaperRequest] FCM 알림 대상 {}명", tokens.size());
+            }
+        } catch (Exception e) {
+            log.error("[PaperRequest] FCM 알림 실패 (요청은 정상 처리)", e);
+        }
+    }
+
+    /** Haversine 공식으로 두 좌표 간 거리(미터) 계산 */
+    private double calculateDistance(double lat1, double lng1, double lat2, double lng2) {
+        final int R = 6371000;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,3 +46,6 @@ springdoc:
     operations-sorter: alpha
   api-docs:
     path: /api-docs
+
+firebase:
+  service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:firebase-service-account.json}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -46,6 +46,39 @@ CREATE TABLE IF NOT EXISTS reviews
     CONSTRAINT fk_review_toilet FOREIGN KEY (toilet_id) REFERENCES toilets (id) ON DELETE CASCADE
     ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
+
+CREATE TABLE IF NOT EXISTS paper_requests
+(
+    id                    BIGINT        NOT NULL AUTO_INCREMENT,
+    toilet_id             BIGINT        NOT NULL,
+    device_id             VARCHAR(100)  NOT NULL,
+    gender                VARCHAR(10)   NOT NULL COMMENT 'MALE | FEMALE',
+    status                VARCHAR(20)   NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE | RESCUED | EXPIRED',
+    requested_at          DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at            DATETIME      NOT NULL COMMENT '요청 후 7분',
+    rescued_at            DATETIME      NULL,
+    rescue_display_until  DATETIME      NULL     COMMENT '구조 완료 후 3분간 *구조* 마커 표시',
+    PRIMARY KEY (id),
+    INDEX idx_paper_status_expires (status, expires_at),
+    INDEX idx_paper_device (device_id),
+    INDEX idx_paper_toilet (toilet_id),
+    CONSTRAINT fk_paper_toilet FOREIGN KEY (toilet_id) REFERENCES toilets (id) ON DELETE CASCADE
+    ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '긴급 휴지 요청';
+
+CREATE TABLE IF NOT EXISTS fcm_tokens
+(
+    id          BIGINT        NOT NULL AUTO_INCREMENT,
+    device_id   VARCHAR(100)  NOT NULL,
+    fcm_token   VARCHAR(500)  NOT NULL,
+    last_lat    DECIMAL(10,7) NULL     COMMENT '마지막 위도',
+    last_lng    DECIMAL(10,7) NULL     COMMENT '마지막 경도',
+    updated_at  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_fcm_device (device_id),
+    INDEX idx_fcm_location (last_lat, last_lng)
+    ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT = '기기별 FCM 토큰';
+
+
 CREATE TABLE IF NOT EXISTS toilet_reports
 (
     id                  BIGINT        NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
휴지 요청 및 FCM 알림 기능을 구현하고, 지도 기반 실시간 상태 표시 및 사용자 알림 흐름을 구축했습니다.  
또한 요청 상태 관리(활성/구조/만료)와 거리 기반 검증, 하루 1회 제한 로직을 포함하여 서비스 안정성을 강화했습니다.

## 주요 변경 사항

- 휴지 요청 도메인 추가
  - `PaperRequest` 엔티티 생성 (ACTIVE / RESCUED / EXPIRED 상태 관리)
  - 요청 생성 시 7분 유효, 구조 시 3분 마커 유지 로직 구현

- FCM 토큰 관리 기능 추가
  - `FcmToken` 엔티티 및 Repository 구현
  - 기기별 토큰 저장 및 위치 기반 갱신 처리

- 휴지 요청 API 구현
  - 요청 생성 (500m 거리 제한 + 하루 1회 제한)
  - 구조 완료 처리 (요청자 본인만 가능)
  - 지도 마커용 활성 요청 조회 (ACTIVE + RESCUED)
  - 특정 화장실 활성 요청 조회
  - 요청 상태 폴링 API 제공
  - FCM 토큰 등록/갱신 API 추가

- 위치 기반 알림 시스템 구축
  - 반경 1km 내 사용자 대상 FCM 푸시 알림 전송
  - Native Query로 주변 사용자 토큰 조회

- 스케줄러 추가
  - 만료된 요청 ACTIVE → EXPIRED 자동 변경

- DTO 설계
  - 지도 마커 전용 응답 (`ActivePaperRequestResponse`)
  - 상세 상태 응답 (`PaperRequestResponse`)
  - 요청 생성 DTO (`PaperRequestCreateRequest`)

- Firebase 연동
  - Firebase Admin SDK 설정 (`FirebaseConfig`)
  - FCM 메시지 전송 서비스 구현 (`FcmService`)

- 예외 처리 확장
  - 거리 초과, 하루 제한, 권한 오류 등 휴지 요청 전용 에러 코드 추가

- DB 스키마 추가
  - `paper_requests`, `fcm_tokens` 테이블 생성
  - 위치 기반 조회 및 상태 조회를 위한 인덱스 구성

## 구성된 파일

- Controller
  - `PaperRequestController.java`

- Domain
  - `PaperRequest.java`
  - `FcmToken.java`

- DTO
  - `PaperRequestCreateRequest.java`
  - `PaperRequestResponse.java`
  - `ActivePaperRequestResponse.java`

- Repository
  - `PaperRequestRepository.java`
  - `FcmTokenRepository.java`

- Service
  - `PaperRequestService.java`
  - `FcmService.java`

- Config
  - `FirebaseConfig.java`

- Global
  - `ErrorCode.java`

- Resources
  - `application.yml`
  - `schema.sql`

- 기타
  - `build.gradle`

## 구현 목적

- 긴급 상황에서 주변 사용자에게 도움을 요청할 수 있는 실시간 기능 제공
- 위치 기반 알림을 통해 사용자 참여 유도
- 지도 UI와 연동 가능한 상태 데이터 제공 (휴지 분수 / 구조 표시)
- 요청 생명주기 관리로 서비스 일관성 및 신뢰성 확보

## 이후 예정 작업

- abuse 방지를 위한 신고/차단 기능 도입