### PR TITLE
feat(global): 에러코드 추가 및 글로벌 예외 핸들러 보강 (#23)

### DIFF
--- a/src/main/java/com/daeddong/global/exception/ErrorCode.java
+++ b/src/main/java/com/daeddong/global/exception/ErrorCode.java
@@ -8,31 +8,57 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    // ── 공통 ──────────────────────────────────────────────────────────────
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
-    TOILET_NOT_FOUND(HttpStatus.NOT_FOUND, "화장실 정보를 찾을 수 없습니다."),
-    INVALID_CROWD_LEVEL(HttpStatus.BAD_REQUEST, "유효하지 않은 혼잡도 값입니다."),
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
-    REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 화장실에 리뷰를 작성하셨습니다."),
-    REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 작성한 리뷰만 삭제할 수 있습니다."),
+    INVALID_ENUM_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 값입니다."),
+    MISSING_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
+    INVALID_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "파라미터 타입이 올바르지 않습니다."),
+    REQUEST_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "요청 데이터 크기가 너무 큽니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
+    UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 Content-Type입니다."),
 
-    // S3 / 이미지
+    // ── 화장실 ────────────────────────────────────────────────────────────
+    TOILET_NOT_FOUND(HttpStatus.NOT_FOUND, "화장실 정보를 찾을 수 없습니다."),
+    INVALID_RADIUS(HttpStatus.BAD_REQUEST, "반경은 100m ~ 5000m 사이여야 합니다."),
+    INVALID_COORDINATES(HttpStatus.BAD_REQUEST, "유효하지 않은 좌표값입니다."),
+    INVALID_OPEN_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 운영 상태입니다. (OPEN / NIGHT / CLOSED)"),
+
+    // ── 혼잡도 ────────────────────────────────────────────────────────────
+    INVALID_CROWD_LEVEL(HttpStatus.BAD_REQUEST, "유효하지 않은 혼잡도 값입니다. (CROWDED / NORMAL / EMPTY)"),
+
+    // ── 리뷰 ──────────────────────────────────────────────────────────────
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
+    REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 화장실에 리뷰를 작성하셨습니다."),
+    REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 작성한 리뷰만 삭제할 수 있습니다."),
+    REVIEW_TOILET_MISMATCH(HttpStatus.BAD_REQUEST, "해당 화장실의 리뷰가 아닙니다."),
+    INVALID_RATING(HttpStatus.BAD_REQUEST, "별점은 1점에서 5점 사이여야 합니다."),
+    REVIEW_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "리뷰 내용은 500자 이하여야 합니다."),
+
+    // ── S3 / 이미지 ───────────────────────────────────────────────────────
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
+    S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다."),
     IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),
     IMAGE_TYPE_INVALID(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다. (jpeg, png, webp, heic 허용)"),
     IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 크기는 10MB 이하여야 합니다."),
 
-    // 제보
+    // ── 제보 ──────────────────────────────────────────────────────────────
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "제보를 찾을 수 없습니다."),
     REPORT_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 작성한 제보만 삭제할 수 있습니다."),
-    REPORT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 제보입니다."),
+    REPORT_ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 제보입니다."),
+    REPORT_DUPLICATE(HttpStatus.CONFLICT, "동일한 위치에 이미 제보가 접수되어 있습니다."),
 
-    // 휴지 요청
+    // ── 휴지 요청 ─────────────────────────────────────────────────────────
     PAPER_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "휴지 요청을 찾을 수 없습니다."),
     PAPER_REQUEST_TOO_FAR(HttpStatus.BAD_REQUEST, "화장실로부터 500m 이내에서만 휴지 요청이 가능합니다."),
-    PAPER_REQUEST_DAILY_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "휴지 요청은 하루에 한 번만 사용할 수 있습니다. 정말 긴급한 상황인가요?!?"),
-    PAPER_REQUEST_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "이미 종료되었거나 만료된 휴지 요청입니다."),
-    PAPER_REQUEST_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 요청한 건만 처리할 수 있습니다.");
+    PAPER_REQUEST_DAILY_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "휴지 요청은 하루에 한 번만 사용할 수 있습니다. 정말 긴급한 상황인가요?!?"),
+    PAPER_REQUEST_NOT_ACTIVE(HttpStatus.CONFLICT, "이미 종료되었거나 만료된 휴지 요청입니다."),
+    PAPER_REQUEST_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 요청한 건만 처리할 수 있습니다."),
+    PAPER_REQUEST_ALREADY_RESCUED(HttpStatus.CONFLICT, "이미 구조 완료된 요청입니다."),
+
+    // ── FCM ───────────────────────────────────────────────────────────────
+    FCM_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 FCM 토큰입니다."),
+    FCM_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "푸시 알림 발송에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/daeddong/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daeddong/global/exception/GlobalExceptionHandler.java
@@ -3,34 +3,104 @@ package com.daeddong.global.exception;
 import com.daeddong.global.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
 import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    // ── 비즈니스 예외 ──────────────────────────────────────────────────────
+
     @ExceptionHandler(DaeddongException.class)
     public ResponseEntity<ApiResponse<Void>> handleDaeddong(DaeddongException e) {
-        log.warn("[DaeddongException] {}", e.getMessage());
+        log.warn("[DaeddongException] code={}, message={}", e.getErrorCode(), e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getStatus())
                 .body(ApiResponse.fail(e.getMessage()));
     }
+
+    // ── @Valid 검증 실패 ───────────────────────────────────────────────────
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
         String message = e.getBindingResult().getFieldErrors().stream()
                 .map(FieldError::getDefaultMessage)
                 .collect(Collectors.joining(", "));
+        log.warn("[ValidationException] {}", message);
         return ResponseEntity.badRequest().body(ApiResponse.fail(message));
     }
 
+    // ── 필수 쿼리 파라미터 누락 ────────────────────────────────────────────
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingParam(MissingServletRequestParameterException e) {
+        String message = "필수 파라미터 '" + e.getParameterName() + "'가 누락되었습니다.";
+        log.warn("[MissingParam] {}", message);
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.fail(message));
+    }
+
+    // ── 파라미터 타입 불일치 (예: Long 자리에 문자열) ───────────────────────
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        String message = "파라미터 '" + e.getName() + "'의 값이 올바르지 않습니다.";
+        log.warn("[TypeMismatch] {}", message);
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.fail(message));
+    }
+
+    // ── JSON 파싱 실패 / Enum 값 오류 ──────────────────────────────────────
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNotReadable(HttpMessageNotReadableException e) {
+        log.warn("[NotReadable] {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.fail(ErrorCode.INVALID_ENUM_VALUE.getMessage()));
+    }
+
+    // ── 파일 크기 초과 ─────────────────────────────────────────────────────
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMaxUploadSize(MaxUploadSizeExceededException e) {
+        log.warn("[MaxUploadSize] {}", e.getMessage());
+        return ResponseEntity.status(ErrorCode.IMAGE_SIZE_EXCEEDED.getStatus())
+                .body(ApiResponse.fail(ErrorCode.IMAGE_SIZE_EXCEEDED.getMessage()));
+    }
+
+    // ── HTTP 메서드 불일치 ─────────────────────────────────────────────────
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
+        log.warn("[MethodNotAllowed] {}", e.getMessage());
+        return ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.getStatus())
+                .body(ApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED.getMessage()));
+    }
+
+    // ── Content-Type 불일치 ────────────────────────────────────────────────
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnsupportedMediaType(HttpMediaTypeNotSupportedException e) {
+        log.warn("[UnsupportedMediaType] {}", e.getMessage());
+        return ResponseEntity.status(ErrorCode.UNSUPPORTED_MEDIA_TYPE.getStatus())
+                .body(ApiResponse.fail(ErrorCode.UNSUPPORTED_MEDIA_TYPE.getMessage()));
+    }
+
+    // ── 예상치 못한 예외 (최후 방어선) ─────────────────────────────────────
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception e) {
-        log.error("[Unexpected]", e);
+        log.error("[Unexpected] {}", e.getMessage(), e);
         return ResponseEntity.internalServerError()
                 .body(ApiResponse.fail(ErrorCode.INTERNAL_ERROR.getMessage()));
     }


### PR DESCRIPTION

글로벌 에러 코드 체계를 확장하고 예외 처리 핸들러를 보강하여 API 에러 응답의 일관성과 안정성을 개선했습니다. 

## 주요 변경 사항
ErrorCode enum 확장 및 도메인별 에러 코드 세분화
공통 / 화장실 / 리뷰 / 제보 / 휴지요청 / 이미지 / FCM 에러 코드 추가
HTTP 상태 코드와 메시지 매핑 구조 정리 및 일부 상태 코드 수정 (BAD_REQUEST → CONFLICT 등)
GlobalExceptionHandler 보강 및 예외 처리 범위 확대
@Valid 검증 실패 메시지 통합 처리
필수 파라미터 누락 / 타입 불일치 예외 처리 추가
JSON 파싱 실패 및 Enum 오류 대응
파일 업로드 크기 초과 예외 처리 추가
HTTP 메서드 및 Content-Type 불일치 예외 처리
예상치 못한 Exception에 대한 최종 방어 처리 강화
로그 출력 개선 (에러 코드 + 메시지 구조화)

## 구성된 파일
src/main/java/com/daeddong/global/exception/ErrorCode.java
src/main/java/com/daeddong/global/exception/GlobalExceptionHandler.java

## 구현 목적
에러 응답의 일관된 구조 제공으로 클라이언트 처리 용이성 확보
도메인별 명확한 에러 정의를 통한 유지보수성 향상
입력값 검증 및 예외 상황에 대한 방어 로직 강화
로그 개선을 통한 디버깅 및 운영 안정성 확보

## 이후 예정 작업
에러 코드 기반 프론트 처리 로직 연동

클로드 코드를 이용한 코드입니다!