### PR TITLE
Refactor : ToiletReport

### DIFF
--- a/src/main/java/com/daeddong/domain/ToiletReport.java
+++ b/src/main/java/com/daeddong/domain/ToiletReport.java
@@ -21,6 +21,10 @@ public class ToiletReport {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 동시 수정 제어를 위한
+    @Version
+    private Long version;
+
     /** 제보한 기기 ID */
     @Column(name = "device_id", nullable = false, length = 100)
     private String deviceId;

--- a/src/main/java/com/daeddong/dto/request/ToiletReportRequest.java
+++ b/src/main/java/com/daeddong/dto/request/ToiletReportRequest.java
@@ -1,6 +1,8 @@
 package com.daeddong.dto.request;
 
 import com.daeddong.domain.Toilet.OpenStatus;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -21,15 +23,21 @@ public class ToiletReportRequest {
     // ── 필수 ──────────────────────────────────────────
 
     @NotBlank(message = "화장실 이름은 필수입니다.")
+    @Size(max = 100, message = "이름은 100자 이하로 입력해주세요.")
     private String name;
 
     @NotBlank(message = "주소는 필수입니다.")
+    @Size(max = 255, message = "주소는 255자 이하로 입력해주세요.")
     private String address;
 
     @NotNull(message = "위도(lat)는 필수입니다.")
+    @DecimalMin(value = "-90.0", message = "위도는 -90 ~ 90 사이여야 합니다.")
+    @DecimalMax(value = "90.0", message = "위도는 -90 ~ 90 사이여야 합니다.")
     private Double lat;
 
     @NotNull(message = "경도(lng)는 필수입니다.")
+    @DecimalMin(value = "-180.0", message = "경도는 -180 ~ 180 사이여야 합니다.")
+    @DecimalMax(value = "180.0", message = "경도는 -180 ~ 180 사이여야 합니다.")
     private Double lng;
 
     // ── 선택 ──────────────────────────────────────────
@@ -44,6 +52,7 @@ public class ToiletReportRequest {
     private Boolean isGenderSep;
 
     /** 운영 시간 (예: "06:00 ~ 22:00", "24시간") */
+    @Size(max = 100, message = "운영시간은 100자 이하로 입력해주세요.")
     private String openHours;
 
     /** 제보자 추가 메모 */

--- a/src/main/java/com/daeddong/global/exception/ErrorCode.java
+++ b/src/main/java/com/daeddong/global/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     REPORT_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 작성한 제보만 삭제할 수 있습니다."),
     REPORT_ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 제보입니다."),
     REPORT_DUPLICATE(HttpStatus.CONFLICT, "동일한 위치에 이미 제보가 접수되어 있습니다."),
+    INVALID_LOCATION(HttpStatus.BAD_REQUEST, "서울 지역만 제보 가능합니다."),
 
     // ── 휴지 요청 ─────────────────────────────────────────────────────────
     PAPER_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "휴지 요청을 찾을 수 없습니다."),

--- a/src/main/java/com/daeddong/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daeddong/global/exception/GlobalExceptionHandler.java
@@ -2,8 +2,10 @@ package com.daeddong.global.exception;
 
 import com.daeddong.global.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -94,6 +96,14 @@ public class GlobalExceptionHandler {
         log.warn("[UnsupportedMediaType] {}", e.getMessage());
         return ResponseEntity.status(ErrorCode.UNSUPPORTED_MEDIA_TYPE.getStatus())
                 .body(ApiResponse.fail(ErrorCode.UNSUPPORTED_MEDIA_TYPE.getMessage()));
+    }
+
+    // ── 동시 수정 ────────────────────────────────────────────────
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<?> handleOptimisticLock() {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body("이미 다른 관리자가 처리한 제보입니다.");
     }
 
     // ── 예상치 못한 예외 (최후 방어선) ─────────────────────────────────────

--- a/src/main/java/com/daeddong/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daeddong/global/exception/GlobalExceptionHandler.java
@@ -102,8 +102,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
     public ResponseEntity<?> handleOptimisticLock() {
         return ResponseEntity
-                .status(HttpStatus.CONFLICT)
-                .body("이미 다른 관리자가 처리한 제보입니다.");
+                .status(ErrorCode.REPORT_DUPLICATE.getStatus())
+                .body(ApiResponse.fail(ErrorCode.REPORT_DUPLICATE.getMessage()));
     }
 
     // ── 예상치 못한 예외 (최후 방어선) ─────────────────────────────────────

--- a/src/main/java/com/daeddong/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daeddong/global/exception/GlobalExceptionHandler.java
@@ -100,9 +100,9 @@ public class GlobalExceptionHandler {
 
     // ── 동시 수정 ────────────────────────────────────────────────
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
-    public ResponseEntity<?> handleOptimisticLock() {
-        return ResponseEntity
-                .status(ErrorCode.REPORT_DUPLICATE.getStatus())
+    public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(ObjectOptimisticLockingFailureException e) {
+        log.warn("[OptimisticLock] {}", e.getMessage());
+        return ResponseEntity.status(ErrorCode.REPORT_DUPLICATE.getStatus())
                 .body(ApiResponse.fail(ErrorCode.REPORT_DUPLICATE.getMessage()));
     }
 

--- a/src/main/java/com/daeddong/repository/ToiletReportRepository.java
+++ b/src/main/java/com/daeddong/repository/ToiletReportRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface ToiletReportRepository extends JpaRepository<ToiletReport, Long> {
 
     /** 상태별 전체 조회 (관리자용) */
@@ -13,4 +15,13 @@ public interface ToiletReportRepository extends JpaRepository<ToiletReport, Long
 
     /** 기기별 본인 제보 목록 */
     Page<ToiletReport> findByDeviceIdOrderByCreatedAtDesc(String deviceId, Pageable pageable);
+
+    /** 중복 제보 방지(연타 - 사용자 실수 방지) */
+    boolean existsByDeviceIdAndNameAndAddressAndStatusAndCreatedAtAfter(
+            String deviceId,
+            String name,
+            String address,
+            ReportStatus status,
+            LocalDateTime createdAt
+    );
 }

--- a/src/main/java/com/daeddong/service/ToiletReportService.java
+++ b/src/main/java/com/daeddong/service/ToiletReportService.java
@@ -35,9 +35,15 @@ public class ToiletReportService {
     /** 화장실 제보 등록 */
     @Transactional
     public ToiletReportResponse createReport(ToiletReportRequest request, MultipartFile image) {
+
+        if (!isInSeoul(request.getLat(), request.getLng())) {
+            throw new DaeddongException(ErrorCode.INVALID_LOCATION);
+        }
+
         String imageUrl = (image != null && !image.isEmpty())
                 ? s3Uploader.upload(image, S3_FOLDER)
                 : null;
+
 
         ToiletReport report = ToiletReport.create(
                 request.getDeviceId(),
@@ -148,5 +154,10 @@ public class ToiletReportService {
     private ToiletReport findReport(Long reportId) {
         return reportRepository.findById(reportId)
                 .orElseThrow(() -> new DaeddongException(ErrorCode.REPORT_NOT_FOUND));
+    }
+
+    private boolean isInSeoul(double lat, double lng) {
+        return (lat >= 37.41 && lat <= 37.70) &&
+                (lng >= 126.73 && lng <= 127.27);
     }
 }

--- a/src/main/java/com/daeddong/service/ToiletReportService.java
+++ b/src/main/java/com/daeddong/service/ToiletReportService.java
@@ -101,6 +101,10 @@ public class ToiletReportService {
             throw new DaeddongException(ErrorCode.REPORT_ALREADY_PROCESSED);
         }
 
+        if (report.getApprovedToiletId() != null) {
+            throw new DaeddongException(ErrorCode.REPORT_ALREADY_PROCESSED);
+        }
+
         // lat/lng → Point 변환 (SRID 4326)
         Point location = geometryFactory.createPoint(
                 new Coordinate(report.getLng(), report.getLat())

--- a/src/main/java/com/daeddong/service/ToiletReportService.java
+++ b/src/main/java/com/daeddong/service/ToiletReportService.java
@@ -20,6 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -36,9 +38,13 @@ public class ToiletReportService {
     @Transactional
     public ToiletReportResponse createReport(ToiletReportRequest request, MultipartFile image) {
 
+        // 서울 여부 확인
         if (!isInSeoul(request.getLat(), request.getLng())) {
             throw new DaeddongException(ErrorCode.INVALID_LOCATION);
         }
+
+        // 중복 제보 확인
+        validateDuplicate(request);
 
         String imageUrl = (image != null && !image.isEmpty())
                 ? s3Uploader.upload(image, S3_FOLDER)
@@ -159,5 +165,31 @@ public class ToiletReportService {
     private boolean isInSeoul(double lat, double lng) {
         return (lat >= 37.41 && lat <= 37.70) &&
                 (lng >= 126.73 && lng <= 127.27);
+    }
+
+    // 사용자 중복 제보 방지(실수 방지)
+    private static final long DUPLICATE_MINUTES = 2;
+
+    private void validateDuplicate(ToiletReportRequest request) {
+
+        LocalDateTime checkTime =
+                LocalDateTime.now()
+                        .minusMinutes(DUPLICATE_MINUTES);
+
+        boolean exists =
+                reportRepository
+                        .existsByDeviceIdAndNameAndAddressAndStatusAndCreatedAtAfter(
+                                request.getDeviceId(),
+                                request.getName().trim(),
+                                request.getAddress().trim(),
+                                ReportStatus.PENDING,
+                                checkTime
+                        );
+
+        if (exists) {
+            throw new DaeddongException(
+                    ErrorCode.REPORT_DUPLICATE
+            );
+        }
     }
 }


### PR DESCRIPTION
# 🛠 ToiletReport 안정성 개선 (동시성 문제)

## 📌 문제

제보 승인 로직에서 동시성 문제가 발생할 수 있었다.

- 여러 관리자가 동시에 같은 제보를 승인할 경우  
- 둘 다 `PENDING` 상태를 확인하고 처리 진행  
- 결과적으로 **화장실 데이터가 중복 생성될 수 있음**

---

## ✅ 해결 방법

### 1. 낙관적 락 적용

```java
@Version
private Long version;
```
- 동시에 수정이 발생하면 하나만 성공
- 나머지는 충돌 발생으로 실패 처리

### 2. 승인 로직 보완
```
if (report.getStatus() != ReportStatus.PENDING) {
    throw new DaeddongException(ErrorCode.REPORT_ALREADY_PROCESSED);
}

if (report.getApprovedToiletId() != null) {
    throw new DaeddongException(ErrorCode.REPORT_ALREADY_PROCESSED);
}
```
- 이미 처리된 데이터는 다시 승인되지 않도록 방어

### 3. 예외 처리 추가
```
@ExceptionHandler(ObjectOptimisticLockingFailureException.class)
public ResponseEntity<?> handleOptimisticLock() {
    return ResponseEntity
            .status(HttpStatus.CONFLICT)
            .body("이미 처리된 제보입니다.");
}
```

# 🛠 ToiletReport 안정성 개선 (위치 검증 ) - 서울 이내 제보 허가

## 📌 문제

기존 제보 등록 로직에는 두 가지 문제가 있었다.

### 1. 서울 외 지역 제보 가능
- 위도/경도 값만 있으면 어디든 제보 가능
- 서비스 정책상 서울 지역만 허용해야 함

---

## ✅ 개선 내용

### 1. 서울 좌표 검증 추가

```java
private boolean isInSeoul(double lat, double lng) {
    return lat >= 37.41 && lat <= 37.70 &&
           lng >= 126.73 && lng <= 127.27;
}
-----

# 🛠 ToiletReport 안정성 개선 (중복 제보 방지)

## 📌 문제

기존 제보 등록 기능은 동일한 요청이 여러 번 들어와도 모두 저장되는 구조였다.

예시:

- 버튼 연속 클릭
- 네트워크 재요청
- 앱 중복 실행
- 동일 요청 반복 전송

이 경우 같은 제보가 여러 개 생성될 수 있었다.

---

## ✅ 기존 방식 검토

처음에는 위도/경도 기반 중복 판정을 고려했다.

예:

- 반경 30m 이내
- 동일 위치

하지만 다음과 같은 문제가 있었다.

- 같은 건물에 화장실이 여러 개 존재 가능
- 강남역처럼 같은 지역 내 화장실이 여러 개 존재 가능
- 가까운 위치의 다른 화장실까지 중복으로 판단될 수 있음

→ 위치만으로 중복 여부를 판단하는 방식은 제외

---

## ✅ 개선 내용

동일 사용자의 짧은 시간 내 반복 요청만 제한하도록 수정했다.

중복 조건:

- 동일 `deviceId`
- 동일 `name`
- 동일 `address`
- 상태 `PENDING`
- 최근 2분 이내 등록

---

## Repository 추가

```java
boolean existsByDeviceIdAndNameAndAddressAndStatusAndCreatedAtAfter(
        String deviceId,
        String name,
        String address,
        ReportStatus status,
        LocalDateTime createdAt
);
```

---

## Service 검증 추가

```java
private static final long DUPLICATE_MINUTES = 2;

private void validateDuplicate(ToiletReportRequest request) {

    LocalDateTime checkTime =
            LocalDateTime.now()
                    .minusMinutes(DUPLICATE_MINUTES);

    boolean exists =
            reportRepository
                    .existsByDeviceIdAndNameAndAddressAndStatusAndCreatedAtAfter(
                            request.getDeviceId(),
                            request.getName().trim(),
                            request.getAddress().trim(),
                            ReportStatus.PENDING,
                            checkTime
                    );

    if (exists) {
        throw new DaeddongException(ErrorCode.REPORT_DUPLICATE);
    }
}
```

---

## 적용

```java
if (!isInSeoul(request.getLat(), request.getLng())) {
    throw new DaeddongException(ErrorCode.INVALID_LOCATION);
}

validateDuplicate(request);
```

---

## 🎯 결과

- 버튼 연타로 인한 중복 저장 방지
- 네트워크 재요청 방지
- 동일 요청 반복 등록 방지
- 실제 다른 화장실 등록은 유지

---

## 🧾 한 줄 정리

👉 동일 사용자의 반복 요청만 제한하여 중복 제보를 방지하도록 수정했다.