### PR TITLE
feat(map): 화장실 검색 기능 추가 #39

### DIFF
--- a/src/main/java/com/daeddong/controller/ToiletController.java
+++ b/src/main/java/com/daeddong/controller/ToiletController.java
@@ -2,6 +2,7 @@ package com.daeddong.controller;
 
 import com.daeddong.dto.request.ToiletNearbyRequest;
 import com.daeddong.dto.response.ToiletDetailResponse;
+import com.daeddong.dto.response.ToiletSearchResponse;
 import com.daeddong.dto.response.ToiletSummaryResponse;
 import com.daeddong.global.response.ApiResponse;
 import com.daeddong.service.ToiletService;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -59,5 +61,26 @@ public class ToiletController {
             @Parameter(description = "화장실 ID") @PathVariable Long id
     ) {
         return ResponseEntity.ok(ApiResponse.ok(toiletService.findDetail(id)));
+    }
+
+    @Operation(summary = "화장실 키워드 검색",
+            description = """
+                    이름 또는 주소에 키워드가 포함된 화장실을 검색합니다.
+                    
+                    - 최소 2자, 최대 50자
+                    - CLOSED 상태 제외
+                    - lat/lng 제공 시 거리순 + distanceMeters 포함 / 미제공 시 이름순
+                    - 최대 20건 반환
+                    """)
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<ToiletSearchResponse>>> search(
+            @Parameter(description = "검색어 (2~50자)", example = "서울시청")
+            @RequestParam @NotBlank String keyword,
+            @Parameter(description = "현재 위도 (거리 계산용, 선택)", example = "37.5665")
+            @RequestParam(required = false) Double lat,
+            @Parameter(description = "현재 경도 (거리 계산용, 선택)", example = "126.9780")
+            @RequestParam(required = false) Double lng
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(toiletService.search(keyword, lat, lng)));
     }
 }

--- a/src/main/java/com/daeddong/dto/response/ToiletSearchResponse.java
+++ b/src/main/java/com/daeddong/dto/response/ToiletSearchResponse.java
@@ -1,0 +1,39 @@
+package com.daeddong.dto.response;
+
+import com.daeddong.domain.Toilet;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ToiletSearchResponse {
+
+    private Long id;
+    private String name;
+    private String address;
+    private Double lat;
+    private Double lng;
+    private Toilet.OpenStatus openStatus;
+    private boolean isDisabled;
+    private boolean isGenderSep;
+
+    /**
+     * 현재 위치로부터의 거리 (미터).
+     * lat/lng 없이 호출한 경우 null.
+     */
+    private Double distanceMeters;
+
+    public static ToiletSearchResponse from(Toilet toilet, Double distanceMeters) {
+        return ToiletSearchResponse.builder()
+                .id(toilet.getId())
+                .name(toilet.getName())
+                .address(toilet.getAddress())
+                .lat(toilet.getLat())
+                .lng(toilet.getLng())
+                .openStatus(toilet.getOpenStatus())
+                .isDisabled(toilet.isDisabled())
+                .isGenderSep(toilet.isGenderSep())
+                .distanceMeters(distanceMeters)
+                .build();
+    }
+}

--- a/src/main/java/com/daeddong/global/exception/ErrorCode.java
+++ b/src/main/java/com/daeddong/global/exception/ErrorCode.java
@@ -59,6 +59,10 @@ public enum ErrorCode {
     PAPER_REQUEST_ALREADY_RESCUED(HttpStatus.CONFLICT, "이미 구조 완료된 요청입니다."),
     PAPER_REQUEST_DUPLICATE(HttpStatus.CONFLICT, "해당 화장실에 이미 진행 중인 휴지 요청이 있습니다."),
 
+    // ── 검색 ──────────────────────────────────────────────────────────────
+    SEARCH_KEYWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "검색어는 2자 이상 입력해주세요."),
+    SEARCH_KEYWORD_TOO_LONG(HttpStatus.BAD_REQUEST, "검색어는 50자 이하로 입력해주세요."),
+
     // ── FCM ───────────────────────────────────────────────────────────────
     FCM_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 FCM 토큰입니다."),
     FCM_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "푸시 알림 발송에 실패했습니다.");

--- a/src/main/java/com/daeddong/repository/ToiletRepository.java
+++ b/src/main/java/com/daeddong/repository/ToiletRepository.java
@@ -17,4 +17,35 @@ public interface ToiletRepository extends JpaRepository<Toilet, Long>, ToiletRep
     List<Toilet> findNearby(@Param("lat") double lat,
                             @Param("lng") double lng,
                             @Param("radius") double radius);
+
+    /**
+     * 키워드 검색: 이름 또는 주소에 keyword 포함된 화장실을 반환.
+     * - lat/lng 있으면 거리순, 없으면 이름순
+     * - CLOSED 상태 제외
+     * - 최대 limit건 반환
+     */
+    @Query(value = """
+            SELECT *,
+                   CASE
+                       WHEN :lat IS NOT NULL AND :lng IS NOT NULL
+                           THEN ST_Distance_Sphere(location, ST_SRID(POINT(:lng, :lat), 4326))
+                       ELSE NULL
+                   END AS distance
+            FROM toilets
+            WHERE open_status != 'CLOSED'
+              AND (name    LIKE CONCAT('%', :keyword, '%')
+                OR address LIKE CONCAT('%', :keyword, '%'))
+            ORDER BY
+                CASE
+                    WHEN :lat IS NOT NULL AND :lng IS NOT NULL
+                        THEN ST_Distance_Sphere(location, ST_SRID(POINT(:lng, :lat), 4326))
+                    ELSE NULL
+                END ASC,
+                name ASC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<Toilet> searchByKeyword(@Param("keyword") String keyword,
+                                 @Param("lat") Double lat,
+                                 @Param("lng") Double lng,
+                                 @Param("limit") int limit);
 }

--- a/src/main/java/com/daeddong/service/ToiletService.java
+++ b/src/main/java/com/daeddong/service/ToiletService.java
@@ -5,6 +5,7 @@ import com.daeddong.domain.Toilet;
 import com.daeddong.dto.request.ToiletNearbyRequest;
 import com.daeddong.dto.response.ToiletDetailResponse;
 import com.daeddong.dto.response.ToiletDetailResponse.TagCount;
+import com.daeddong.dto.response.ToiletSearchResponse;
 import com.daeddong.dto.response.ToiletSummaryResponse;
 import com.daeddong.global.exception.DaeddongException;
 import com.daeddong.global.exception.ErrorCode;
@@ -81,5 +82,48 @@ public class ToiletService {
                 .map(ToiletSummaryResponse::from)
                 .orElseThrow(() -> new DaeddongException(
                         ErrorCode.TOILET_NOT_FOUND, "주변 5km 내 화장실이 없습니다."));
+    }
+
+    // ── 키워드 검색 ──────────────────────────────────────────────────────
+
+    private static final int SEARCH_MAX_RESULTS = 20;
+
+    /**
+     * 이름 또는 주소에 keyword가 포함된 화장실 검색.
+     * - 2자 이상, 50자 이하
+     * - CLOSED 제외
+     * - lat/lng 있으면 거리순 + distanceMeters 포함, 없으면 이름순
+     * - 최대 20건
+     */
+    public List<ToiletSearchResponse> search(String keyword, Double lat, Double lng) {
+        String trimmed = keyword.trim();
+        if (trimmed.length() < 2) {
+            throw new DaeddongException(ErrorCode.SEARCH_KEYWORD_TOO_SHORT);
+        }
+        if (trimmed.length() > 50) {
+            throw new DaeddongException(ErrorCode.SEARCH_KEYWORD_TOO_LONG);
+        }
+
+        return toiletRepository
+                .searchByKeyword(trimmed, lat, lng, SEARCH_MAX_RESULTS)
+                .stream()
+                .map(toilet -> {
+                    Double distance = (lat != null && lng != null)
+                            ? calculateDistance(lat, lng, toilet.getLat(), toilet.getLng())
+                            : null;
+                    return ToiletSearchResponse.from(toilet, distance);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /** Haversine 공식으로 두 좌표 간 거리(미터) 계산 */
+    private double calculateDistance(double lat1, double lng1, double lat2, double lng2) {
+        final int R = 6371000;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
     }
 }


### PR DESCRIPTION
Spring Boot 기반 대똥여지도 서버에 화장실 키워드 검색 기능을 추가했습니다. 이름 또는 주소 기반 검색과 현재 위치 기준 거리 정렬을 지원합니다.

---

**주요 변경 사항**

- `GET /api/v1/toilets/search` 엔드포인트 추가
  - 이름 또는 주소에 키워드가 포함된 화장실 검색
  - CLOSED 상태 화장실 자동 제외
  - `lat`/`lng` 제공 시 거리순 정렬 및 `distanceMeters` 응답 포함, 미제공 시 이름순
  - 최대 20건 반환

---

**구성된 파일**

- `src/main/java/com/daeddong/controller/ToiletController.java`
- `src/main/java/com/daeddong/service/ToiletService.java`
- `src/main/java/com/daeddong/repository/ToiletRepository.java`
- `src/main/java/com/daeddong/dto/response/ToiletSearchResponse.java`
- `src/main/java/com/daeddong/global/exception/ErrorCode.java`

---

**구현 목적**

- 지도에서 특정 화장실을 이름/주소로 빠르게 찾을 수 있는 검색 UX 제공
- 현재 위치 기반 거리 정렬로 가까운 결과 우선 노출
- 검색어 유효성 검증(2자 이상, 50자 이하) 및 에러 응답 표준화

---

**이후 예정 작업**

- Flutter 검색 UI 연동